### PR TITLE
fix: moved tsconfig-paths to dependencies section

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "pg": "^8.16.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "tsconfig-paths": "^4.2.0",
     "typeorm": "^0.3.24"
   },
   "devDependencies": {
@@ -62,7 +63,6 @@
     "ts-jest": "^29.2.5",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
-    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
   },


### PR DESCRIPTION
fix: moved tsconfig-paths to dependencies section as it is needed in runtime for TypeORM migrations.