### PR TITLE
chore: Made redis configurable and removed unused cacheable dependency 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
 DB_DATABASE=f1_db
+REDIS_ENABLED=true
 REDIS_HOST=localhost
 REDIS_PORT=6379
 ```
@@ -125,7 +126,7 @@ npm run start:prod
 
 Build the Docker image:
 ```bash
-docker build -t sarnenduhexa/f1-dashboard-backend:latest .
+docker build -t sarnenduhexa/f1-be:latest .
 ```
 
 ### Running with Docker
@@ -133,14 +134,14 @@ docker build -t sarnenduhexa/f1-dashboard-backend:latest .
 Run the container with environment variables:
 ```bash
 docker run -d \
-  --name f1-dashboard-backend \
+  --name f1-be \
   -p 3000:3000 \
   -e DB_HOST=localhost \
   -e DB_PORT=5432 \
   -e DB_USERNAME=postgres \
   -e DB_PASSWORD=postgres \
   -e DB_DATABASE=f1_db \
-  sarnenduhexa/f1-dashboard-backend:latest
+  sarnenduhexa/f1-be:latest
 ```
 
 ### Publishing to Docker Hub
@@ -152,7 +153,7 @@ docker login
 
 2. Push the image:
 ```bash
-docker push sarnenduhexa/f1-dashboard-backend:latest
+docker push sarnenduhexa/f1-be:latest
 ```
 
 ## CI/CD Pipeline
@@ -315,8 +316,8 @@ Redis caching is configured in `app.module.ts` with the following default settin
 - Maximum items: 100
 
 The application uses a two-tier caching strategy:
-1. In-memory cache (first tier) using `CacheableMemory`
-2. Redis cache (second tier) using `@keyv/redis`
+1. In-memory cache (first tier).
+2. Redis cache (second tier) using `@keyv/redis` (Conditionally, configured by ENV variables)
 
 ### Usage in Controllers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@nestjs/typeorm": "^11.0.0",
         "axios": "^1.9.0",
         "cache-manager": "^6.4.3",
-        "cacheable": "^1.9.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "pg": "^8.16.0",
@@ -5579,16 +5578,6 @@
         "keyv": "^5.3.3"
       }
     },
-    "node_modules/cacheable": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.9.0.tgz",
-      "integrity": "sha512-8D5htMCxPDUULux9gFzv30f04Xo3wCnik0oOxKoRTPIBoqA7HtOcJ87uBhQTs3jCfZZTrUBGsYIZOgE0ZRgMAg==",
-      "license": "MIT",
-      "dependencies": {
-        "hookified": "^1.8.2",
-        "keyv": "^5.3.3"
-      }
-    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -7817,12 +7806,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/hookified": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.9.0.tgz",
-      "integrity": "sha512-2yEEGqphImtKIe1NXWEhu6yD3hlFR4Mxk4Mtp3XEyScpSt4pQ4ymmXA1zzxZpj99QkFK+nN0nzjeb2+RUi/6CQ==",
-      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -16411,15 +16394,6 @@
         "keyv": "^5.3.3"
       }
     },
-    "cacheable": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.9.0.tgz",
-      "integrity": "sha512-8D5htMCxPDUULux9gFzv30f04Xo3wCnik0oOxKoRTPIBoqA7HtOcJ87uBhQTs3jCfZZTrUBGsYIZOgE0ZRgMAg==",
-      "requires": {
-        "hookified": "^1.8.2",
-        "keyv": "^5.3.3"
-      }
-    },
     "cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -17857,11 +17831,6 @@
       "requires": {
         "function-bind": "^1.1.2"
       }
-    },
-    "hookified": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.9.0.tgz",
-      "integrity": "sha512-2yEEGqphImtKIe1NXWEhu6yD3hlFR4Mxk4Mtp3XEyScpSt4pQ4ymmXA1zzxZpj99QkFK+nN0nzjeb2+RUi/6CQ=="
     },
     "html-escaper": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@nestjs/typeorm": "^11.0.0",
     "axios": "^1.9.0",
     "cache-manager": "^6.4.3",
-    "cacheable": "^1.9.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "pg": "^8.16.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,7 +8,6 @@ import { DriversModule } from './drivers/drivers.module';
 import { HealthModule } from './health/health.module';
 import configuration from './config/configuration';
 import { createKeyv, Keyv } from '@keyv/redis';
-import { CacheableMemory } from 'cacheable';
 
 @Module({
   imports: [
@@ -20,19 +19,17 @@ import { CacheableMemory } from 'cacheable';
       isGlobal: true,
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => {
-        return {
-          stores: [
-            new Keyv({
-              store: new CacheableMemory({
-                ttl: configService.get('redis.ttl'),
-                lruSize: configService.get('redis.max'),
-              }),
-            }),
+        const stores: Keyv[] = [];
+        if (configService.get('cache.redis.enabled')) {
+          stores.push(
             createKeyv(
-              `redis://${configService.get('redis.host')}:${configService.get('redis.port')}`,
+              `redis://${configService.get('cache.redis.host')}:${configService.get('cache.redis.port')}`,
             ),
-          ],
-          ttl: configService.get('redis.ttl'),
+          );
+        }
+        return {
+          stores,
+          ttl: configService.get('cache.ttl'),
         };
       },
       inject: [ConfigService],

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -8,11 +8,14 @@ export default () => ({
     database: process.env.DB_DATABASE || 'f1_db',
     synchronize: process.env.NODE_ENV === 'development',
   },
-  redis: {
-    host: process.env.REDIS_HOST || 'localhost',
-    port: parseInt(process.env.REDIS_PORT || '6379', 10),
+  cache: {
     ttl: 60 * 1000, // 1 minute
     max: 100, // maximum number of items in cache
+    redis: {
+      enabled: process.env.REDIS_ENABLED === 'true',
+      host: process.env.REDIS_HOST || 'localhost',
+      port: parseInt(process.env.REDIS_PORT || '6379', 10),
+    },
   },
   ergastApi: {
     baseUrl: 'https://api.jolpi.ca/ergast',

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Logger } from '@nestjs/common';
 import {
   HealthCheck,
   HealthCheckService,
@@ -8,6 +8,7 @@ import {
 
 @Controller('health')
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
   constructor(
     private health: HealthCheckService,
     private http: HttpHealthIndicator,
@@ -17,6 +18,7 @@ export class HealthController {
   @Get()
   @HealthCheck()
   check() {
+    this.logger.debug('Checking health');
     return this.health.check([
       // HTTP health check
       // As this is rate limited, this is not reliable.

--- a/src/races/races.service.ts
+++ b/src/races/races.service.ts
@@ -27,6 +27,7 @@ export class RacesService {
   ) {}
 
   async findBySeason(season: number): Promise<Race[]> {
+    this.logger.debug(`Finding races for season ${season}`);
     const baseUrl = this.configService.get<string>('ergastApi.baseUrl');
     try {
       // First check if we have races for this season
@@ -113,6 +114,7 @@ export class RacesService {
   }
 
   private async fetchAndStoreRacesBySeason(season: number): Promise<Race[]> {
+    this.logger.debug(`Fetching and storing races for season ${season}`);
     const baseUrl = this.configService.get<string>('ergastApi.baseUrl');
     try {
       const response = await axios.get<ErgastResponse>(

--- a/src/seasons/seasons.service.ts
+++ b/src/seasons/seasons.service.ts
@@ -20,6 +20,7 @@ export class SeasonsService {
   ) {}
 
   async findAll(): Promise<SeasonDto[]> {
+    this.logger.debug('Finding all seasons');
     const seasons = await this.seasonsRepository.find({
       order: { year: 'ASC' },
       relations: ['winner'],
@@ -58,6 +59,7 @@ export class SeasonsService {
   }
 
   async findOne(year: number): Promise<SeasonDto> {
+    this.logger.debug(`Finding season ${year}`);
     try {
       // First try to find the season in the database
       let season = await this.seasonsRepository.findOne({


### PR DESCRIPTION
chore: remove unused cacheable dependency and update Docker image references

- Removed the `cacheable` dependency from package.json and package-lock.json as it is no longer needed.
- Updated README to reflect changes in Docker image naming from `f1-dashboard-backend` to `f1-be`.
- Added a new environment variable `REDIS_ENABLED` to control Redis caching configuration.