### PR TITLE
feat: integrate scheduling functionality with new Jobs module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.0.0",
         "@nestjs/swagger": "^11.2.0",
         "@nestjs/terminus": "^11.0.0",
         "@nestjs/typeorm": "^11.0.0",
@@ -2665,6 +2666,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.0.0.tgz",
+      "integrity": "sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.3.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.5.tgz",
@@ -3641,6 +3655,12 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
       "license": "MIT"
     },
     "node_modules/@types/methods": {
@@ -6172,6 +6192,19 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.0.tgz",
+      "integrity": "sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -9171,6 +9204,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {
@@ -14487,6 +14529,14 @@
         "tslib": "2.8.1"
       }
     },
+    "@nestjs/schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.0.0.tgz",
+      "integrity": "sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==",
+      "requires": {
+        "cron": "4.3.0"
+      }
+    },
     "@nestjs/schematics": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.5.tgz",
@@ -15088,6 +15138,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw=="
     },
     "@types/methods": {
       "version": "1.1.4",
@@ -16774,6 +16829,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "cron": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.0.tgz",
+      "integrity": "sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==",
+      "requires": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      }
     },
     "cross-spawn": {
       "version": "7.0.6",
@@ -18774,6 +18838,11 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ=="
     },
     "magic-string": {
       "version": "0.30.17",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.0.0",
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/terminus": "^11.0.0",
     "@nestjs/typeorm": "^11.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CacheModule } from '@nestjs/cache-manager';
+import { ScheduleModule } from '@nestjs/schedule';
 import { SeasonsModule } from './seasons/seasons.module';
 import { RacesModule } from './races/races.module';
 import { DriversModule } from './drivers/drivers.module';
 import { HealthModule } from './health/health.module';
+import { JobsModule } from './jobs/jobs.module';
 import configuration from './config/configuration';
 import { createKeyv, Keyv } from '@keyv/redis';
 
@@ -48,10 +50,12 @@ import { createKeyv, Keyv } from '@keyv/redis';
       }),
       inject: [ConfigService],
     }),
+    ScheduleModule.forRoot(),
     SeasonsModule,
     RacesModule,
     DriversModule,
     HealthModule,
+    JobsModule,
   ],
   controllers: [],
   providers: [],

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { JobsService } from './jobs.service';
+import { SeasonsModule } from '../seasons/seasons.module';
+import { RacesModule } from '../races/races.module';
+
+@Module({
+  imports: [SeasonsModule, RacesModule],
+  providers: [JobsService],
+})
+export class JobsModule {}

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { SeasonsService } from '../seasons/seasons.service';
+import { RacesService } from '../races/races.service';
+
+@Injectable()
+export class JobsService {
+  private readonly logger = new Logger(JobsService.name);
+
+  constructor(
+    private readonly seasonsService: SeasonsService,
+    private readonly racesService: RacesService,
+  ) {}
+
+  // For local testing, you can change it to run every minute using:
+  // @Cron(CronExpression.EVERY_MINUTE)
+  // Run every Sunday at 1 am (0 1 * * 0)
+  @Cron('0 1 * * 0')
+  async syncSeasons() {
+    try {
+      this.logger.log('Seasons sync: Starting');
+
+      await this.seasonsService.syncSeasons();
+
+      this.logger.log('Seasons sync: Completed successfully');
+    } catch (error) {
+      this.logger.error(
+        `Error syncing seasons: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw error;
+    }
+  }
+  // For local testing, you can change it to run every minute using:
+  // @Cron(CronExpression.EVERY_MINUTE)
+  // Run every Sunday at 3 am (0 3 * * 0)
+  @Cron('0 3 * * 0')
+  async syncCurrentSeasonRaces() {
+    try {
+      this.logger.log('Current season races sync: Starting');
+
+      // Get current season
+      const currentYear = new Date().getFullYear();
+      await this.racesService.syncRaces(currentYear);
+
+      this.logger.log('Current season races sync: Completed successfully');
+    } catch (error) {
+      this.logger.error(
+        `Error syncing current season races: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw error;
+    }
+  }
+}

--- a/src/races/interfaces/ergast-response.interface.ts
+++ b/src/races/interfaces/ergast-response.interface.ts
@@ -67,3 +67,7 @@ export interface ErgastResponse {
     RaceTable: ErgastRaceTable;
   };
 }
+
+export interface RaceWithWinner extends ErgastRace {
+  winnerData: ErgastResult | null;
+}

--- a/src/races/races.module.ts
+++ b/src/races/races.module.ts
@@ -9,5 +9,6 @@ import { DriversModule } from '../drivers/drivers.module';
   imports: [TypeOrmModule.forFeature([Race]), DriversModule],
   controllers: [RacesController],
   providers: [RacesService],
+  exports: [RacesService],
 })
 export class RacesModule {}

--- a/src/races/races.service.spec.ts
+++ b/src/races/races.service.spec.ts
@@ -5,7 +5,10 @@ import { RacesService } from './races.service';
 import { Race } from './entities/race.entity';
 import { DriversService } from '../drivers/drivers.service';
 import axios from 'axios';
-import { ErgastResponse } from './interfaces/ergast-response.interface';
+import {
+  ErgastResponse,
+  RaceWithWinner,
+} from './interfaces/ergast-response.interface';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -74,11 +77,11 @@ describe('RacesService', () => {
   };
 
   const mockConfigService = {
-    get: jest.fn().mockReturnValue('https://api.jolpi.ca/ergast'),
+    get: () => 'https://api.jolpi.ca/ergast',
   };
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   beforeEach(async () => {
@@ -136,6 +139,23 @@ describe('RacesService', () => {
             season: '2023',
             Races: [
               {
+                season: '2023',
+                round: '1',
+                raceName: 'Bahrain Grand Prix',
+                Circuit: {
+                  circuitId: 'bahrain',
+                  circuitName: 'Bahrain International Circuit',
+                  url: 'http://en.wikipedia.org/wiki/Bahrain_International_Circuit',
+                  Location: {
+                    lat: '26.0325',
+                    long: '50.5106',
+                    locality: 'Sakhir',
+                    country: 'Bahrain',
+                  },
+                },
+                date: '2023-03-05',
+                time: '15:00:00Z',
+                url: 'https://api.jolpi.ca/ergast/f1/2023/1',
                 Results: [
                   {
                     Driver: mockDriver,
@@ -152,23 +172,6 @@ describe('RacesService', () => {
                     status: 'Finished',
                   },
                 ],
-                season: '2023',
-                round: '1',
-                url: 'https://api.jolpi.ca/ergast/f1/2023/1',
-                raceName: 'Bahrain Grand Prix',
-                Circuit: {
-                  circuitId: 'bahrain',
-                  circuitName: 'Bahrain International Circuit',
-                  url: 'http://en.wikipedia.org/wiki/Bahrain_International_Circuit',
-                  Location: {
-                    lat: '26.0325',
-                    long: '50.5106',
-                    locality: 'Sakhir',
-                    country: 'Bahrain',
-                  },
-                },
-                date: '2023-03-05',
-                time: '15:00:00Z',
               },
             ],
           },
@@ -184,7 +187,7 @@ describe('RacesService', () => {
         ...mockRaceWithoutWinner,
         winnerDriverId: mockDriver.driverId,
         winnerDriver: mockDriver,
-        winnerConstructorId: null,
+        winnerConstructorId: 'red_bull',
         winnerTime: '1:33:56.736',
         winnerLaps: 57,
         winnerGrid: 1,
@@ -242,6 +245,23 @@ describe('RacesService', () => {
             season: '2023',
             Races: [
               {
+                season: '2023',
+                round: '1',
+                raceName: 'Bahrain Grand Prix',
+                Circuit: {
+                  circuitId: 'bahrain',
+                  circuitName: 'Bahrain International Circuit',
+                  url: 'http://en.wikipedia.org/wiki/Bahrain_International_Circuit',
+                  Location: {
+                    lat: '26.0325',
+                    long: '50.5106',
+                    locality: 'Sakhir',
+                    country: 'Bahrain',
+                  },
+                },
+                date: '2023-03-05',
+                time: '15:00:00Z',
+                url: 'https://api.jolpi.ca/ergast/f1/2023/1',
                 Results: [
                   {
                     Driver: mockDriver,
@@ -258,23 +278,6 @@ describe('RacesService', () => {
                     status: 'Finished',
                   },
                 ],
-                season: '2023',
-                round: '1',
-                url: 'https://api.jolpi.ca/ergast/f1/2023/1',
-                raceName: 'Bahrain Grand Prix',
-                Circuit: {
-                  circuitId: 'bahrain',
-                  circuitName: 'Bahrain International Circuit',
-                  url: 'http://en.wikipedia.org/wiki/Bahrain_International_Circuit',
-                  Location: {
-                    lat: '26.0325',
-                    long: '50.5106',
-                    locality: 'Sakhir',
-                    country: 'Bahrain',
-                  },
-                },
-                date: '2023-03-05',
-                time: '15:00:00Z',
               },
             ],
           },
@@ -285,15 +288,33 @@ describe('RacesService', () => {
         .mockResolvedValueOnce({ data: mockRacesResponse })
         .mockResolvedValueOnce({ data: mockWinnerResponse });
 
+      mockRepository.find.mockResolvedValueOnce([]);
+
       mockDriversService.findOrCreate.mockResolvedValue(mockDriver);
       mockRepository.save.mockResolvedValue([mockRace]);
+
       mockRepository.find.mockResolvedValueOnce([mockRace]);
 
       const result = await service.findBySeason(2023);
 
       expect(result).toEqual([mockRace]);
       expect(mockRepository.save).toHaveBeenCalledWith([
-        mockRaceWithoutWinnerDriver,
+        {
+          id: '2023-1',
+          season: 2023,
+          round: 1,
+          raceName: 'Bahrain Grand Prix',
+          circuitName: 'Bahrain International Circuit',
+          date: new Date('2023-03-05'),
+          time: '15:00:00Z',
+          url: 'https://api.jolpi.ca/ergast/f1/2023/1',
+          winnerDriverId: mockDriver.driverId,
+          winnerConstructorId: 'red_bull',
+          winnerTime: '1:33:56.736',
+          winnerLaps: 57,
+          winnerGrid: 1,
+          winnerPoints: 25,
+        },
       ]);
     });
 
@@ -333,26 +354,452 @@ describe('RacesService', () => {
           },
         },
       };
-      const expectedRaceWithoutWinner = {
-        id: '2023-1',
-        season: 2023,
-        round: 1,
-        raceName: 'Bahrain Grand Prix',
-        circuitName: 'Bahrain International Circuit',
-        date: new Date('2023-03-05'),
-        time: '15:00:00Z',
-        url: 'https://api.jolpi.ca/ergast/f1/2023/1',
-      };
+
       mockedAxios.get
         .mockResolvedValueOnce({ data: mockRacesResponse })
         .mockRejectedValueOnce(new Error('API Error'));
+
+      mockRepository.find.mockResolvedValueOnce([]);
       mockRepository.save.mockResolvedValue([mockRaceWithoutWinner]);
       mockRepository.find.mockResolvedValueOnce([mockRaceWithoutWinner]);
 
       const result = await service.findBySeason(2023);
       expect(result).toEqual([mockRaceWithoutWinner]);
       expect(mockRepository.save).toHaveBeenCalledWith([
-        expectedRaceWithoutWinner,
+        {
+          id: '2023-1',
+          season: 2023,
+          round: 1,
+          raceName: 'Bahrain Grand Prix',
+          circuitName: 'Bahrain International Circuit',
+          date: new Date('2023-03-05'),
+          time: '15:00:00Z',
+          url: 'https://api.jolpi.ca/ergast/f1/2023/1',
+        },
+      ]);
+    });
+  });
+
+  describe('syncRaces', () => {
+    it('should fetch and store races for a given season', async () => {
+      const mockRacesResponse: ErgastResponse = {
+        MRData: {
+          xmlns: '',
+          series: '',
+          url: '',
+          limit: '',
+          offset: '',
+          total: '',
+          RaceTable: {
+            season: '2023',
+            Races: [
+              {
+                season: '2023',
+                round: '1',
+                raceName: 'Bahrain Grand Prix',
+                Circuit: {
+                  circuitId: 'bahrain',
+                  circuitName: 'Bahrain International Circuit',
+                  url: 'http://en.wikipedia.org/wiki/Bahrain_International_Circuit',
+                  Location: {
+                    lat: '26.0325',
+                    long: '50.5106',
+                    locality: 'Sakhir',
+                    country: 'Bahrain',
+                  },
+                },
+                date: '2023-03-05',
+                time: '15:00:00Z',
+                url: 'https://api.jolpi.ca/ergast/f1/2023/1',
+              },
+            ],
+          },
+        },
+      };
+
+      const mockWinnerResponse: ErgastResponse = {
+        MRData: {
+          xmlns: '',
+          series: '',
+          url: '',
+          limit: '',
+          offset: '',
+          total: '',
+          RaceTable: {
+            season: '2023',
+            Races: [
+              {
+                season: '2023',
+                round: '1',
+                raceName: 'Bahrain Grand Prix',
+                Circuit: {
+                  circuitId: 'bahrain',
+                  circuitName: 'Bahrain International Circuit',
+                  url: 'http://en.wikipedia.org/wiki/Bahrain_International_Circuit',
+                  Location: {
+                    lat: '26.0325',
+                    long: '50.5106',
+                    locality: 'Sakhir',
+                    country: 'Bahrain',
+                  },
+                },
+                date: '2023-03-05',
+                time: '15:00:00Z',
+                url: 'https://api.jolpi.ca/ergast/f1/2023/1',
+                Results: [
+                  {
+                    Driver: mockDriver,
+                    Constructor: {
+                      constructorId: 'red_bull',
+                      url: 'http://en.wikipedia.org/wiki/Red_Bull_Racing',
+                      name: 'Red Bull',
+                      nationality: 'Austrian',
+                    },
+                    Time: { millis: '56367636', time: '1:33:56.736' },
+                    laps: '57',
+                    grid: '1',
+                    points: '25',
+                    status: 'Finished',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      };
+
+      mockRepository.find.mockResolvedValue([]);
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: mockRacesResponse })
+        .mockResolvedValueOnce({ data: mockWinnerResponse });
+
+      mockDriversService.findOrCreate.mockResolvedValue(mockDriver);
+
+      await service.syncRaces(2023);
+
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        'https://api.jolpi.ca/ergast/f1/2023/races',
+      );
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        'https://api.jolpi.ca/ergast/f1/2023/1/results.json?limit=1',
+      );
+      expect(mockRepository.save).toHaveBeenCalledWith([
+        {
+          id: '2023-1',
+          season: 2023,
+          round: 1,
+          raceName: 'Bahrain Grand Prix',
+          circuitName: 'Bahrain International Circuit',
+          date: new Date('2023-03-05'),
+          time: '15:00:00Z',
+          url: 'https://api.jolpi.ca/ergast/f1/2023/1',
+          winnerDriverId: mockDriver.driverId,
+          winnerConstructorId: 'red_bull',
+          winnerTime: '1:33:56.736',
+          winnerLaps: 57,
+          winnerGrid: 1,
+          winnerPoints: 25,
+        },
+      ]);
+    });
+
+    it('should handle errors during race synchronization', async () => {
+      mockedAxios.get.mockRejectedValue(new Error('API Error'));
+
+      await expect(service.syncRaces(2023)).rejects.toThrow('API Error');
+    });
+  });
+
+  describe('processAndStoreRaces', () => {
+    it('should process and store new races with correct ordering', async () => {
+      const newRaces: RaceWithWinner[] = [
+        {
+          season: '2023',
+          round: '2',
+          raceName: 'Saudi Arabian Grand Prix',
+          Circuit: {
+            circuitId: 'jeddah',
+            circuitName: 'Jeddah Corniche Circuit',
+            url: 'http://en.wikipedia.org/wiki/Jeddah_Corniche_Circuit',
+            Location: {
+              lat: '21.5433',
+              long: '39.1728',
+              locality: 'Jeddah',
+              country: 'Saudi Arabia',
+            },
+          },
+          date: '2023-03-19',
+          time: '17:00:00Z',
+          url: 'https://api.jolpi.ca/ergast/f1/2023/2',
+          winnerData: {
+            Driver: mockDriver,
+            Constructor: {
+              constructorId: 'red_bull',
+              url: 'http://en.wikipedia.org/wiki/Red_Bull_Racing',
+              name: 'Red Bull',
+              nationality: 'Austrian',
+            },
+            Time: { millis: '56367636', time: '1:33:56.736' },
+            laps: '57',
+            grid: '1',
+            points: '25',
+            status: 'Finished',
+          },
+        },
+      ];
+
+      mockRepository.find.mockResolvedValue([
+        {
+          ...mockRace,
+          round: 1,
+        },
+        {
+          ...mockRace,
+          round: 2,
+        },
+      ]);
+
+      await service['processAndStoreRaces'](newRaces, 2023);
+
+      expect(mockRepository.save).toHaveBeenCalledWith([
+        {
+          id: '2023-2',
+          season: 2023,
+          round: 2,
+          raceName: 'Saudi Arabian Grand Prix',
+          circuitName: 'Jeddah Corniche Circuit',
+          date: new Date('2023-03-19'),
+          time: '17:00:00Z',
+          url: 'https://api.jolpi.ca/ergast/f1/2023/2',
+          winnerDriverId: mockDriver.driverId,
+          winnerConstructorId: 'red_bull',
+          winnerTime: '1:33:56.736',
+          winnerLaps: 57,
+          winnerGrid: 1,
+          winnerPoints: 25,
+        },
+      ]);
+
+      expect(mockRepository.find).toHaveBeenCalledWith({
+        where: { season: 2023 },
+        order: { round: 'ASC' },
+        relations: ['winnerDriver'],
+      });
+    });
+
+    it('should handle empty new races array', async () => {
+      mockRepository.find.mockResolvedValue([mockRace]);
+
+      await service['processAndStoreRaces']([], 2023);
+
+      expect(mockRepository.save).not.toHaveBeenCalled();
+      expect(mockRepository.find).toHaveBeenCalledWith({
+        where: { season: 2023 },
+        order: { round: 'ASC' },
+        relations: ['winnerDriver'],
+      });
+    });
+  });
+
+  describe('fetchAndStoreRacesBySeason', () => {
+    it('should fetch and store races with winner data', async () => {
+      const mockRacesResponse: ErgastResponse = {
+        MRData: {
+          xmlns: '',
+          series: '',
+          url: '',
+          limit: '',
+          offset: '',
+          total: '',
+          RaceTable: {
+            season: '2023',
+            Races: [
+              {
+                season: '2023',
+                round: '1',
+                raceName: 'Bahrain Grand Prix',
+                Circuit: {
+                  circuitId: 'bahrain',
+                  circuitName: 'Bahrain International Circuit',
+                  url: 'http://en.wikipedia.org/wiki/Bahrain_International_Circuit',
+                  Location: {
+                    lat: '26.0325',
+                    long: '50.5106',
+                    locality: 'Sakhir',
+                    country: 'Bahrain',
+                  },
+                },
+                date: '2023-03-05',
+                time: '15:00:00Z',
+                url: 'https://api.jolpi.ca/ergast/f1/2023/1',
+              },
+              {
+                season: '2023',
+                round: '2',
+                raceName: 'Saudi Arabian Grand Prix',
+                Circuit: {
+                  circuitId: 'jeddah',
+                  circuitName: 'Jeddah Corniche Circuit',
+                  url: 'http://en.wikipedia.org/wiki/Jeddah_Corniche_Circuit',
+                  Location: {
+                    lat: '21.5433',
+                    long: '39.1728',
+                    locality: 'Jeddah',
+                    country: 'Saudi Arabia',
+                  },
+                },
+                date: '2023-03-19',
+                time: '17:00:00Z',
+                url: 'https://api.jolpi.ca/ergast/f1/2023/2',
+              },
+            ],
+          },
+        },
+      };
+
+      const mockWinnerResponse: ErgastResponse = {
+        MRData: {
+          xmlns: '',
+          series: '',
+          url: '',
+          limit: '',
+          offset: '',
+          total: '',
+          RaceTable: {
+            season: '2023',
+            Races: [
+              {
+                season: '2023',
+                round: '2',
+                raceName: 'Saudi Arabian Grand Prix',
+                Circuit: {
+                  circuitId: 'jeddah',
+                  circuitName: 'Jeddah Corniche Circuit',
+                  url: 'http://en.wikipedia.org/wiki/Jeddah_Corniche_Circuit',
+                  Location: {
+                    lat: '21.5433',
+                    long: '39.1728',
+                    locality: 'Jeddah',
+                    country: 'Saudi Arabia',
+                  },
+                },
+                date: '2023-03-19',
+                time: '17:00:00Z',
+                url: 'https://api.jolpi.ca/ergast/f1/2023/2',
+                Results: [
+                  {
+                    Driver: mockDriver,
+                    Constructor: {
+                      constructorId: 'red_bull',
+                      url: 'http://en.wikipedia.org/wiki/Red_Bull_Racing',
+                      name: 'Red Bull',
+                      nationality: 'Austrian',
+                    },
+                    Time: { millis: '56367636', time: '1:33:56.736' },
+                    laps: '57',
+                    grid: '1',
+                    points: '25',
+                    status: 'Finished',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      };
+
+      // Mock existing races in database
+      const existingRaces = [
+        {
+          ...mockRace,
+          round: 1,
+        },
+      ];
+
+      mockRepository.find.mockResolvedValue(existingRaces);
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: mockRacesResponse })
+        .mockResolvedValueOnce({ data: mockWinnerResponse });
+      mockDriversService.findOrCreate.mockResolvedValue(mockDriver);
+
+      await service['fetchAndStoreRacesBySeason'](2023);
+
+      // Verify that only the new race (round 2) is processed
+      expect(mockRepository.save).toHaveBeenCalledWith([
+        {
+          id: '2023-2',
+          season: 2023,
+          round: 2,
+          raceName: 'Saudi Arabian Grand Prix',
+          circuitName: 'Jeddah Corniche Circuit',
+          date: new Date('2023-03-19'),
+          time: '17:00:00Z',
+          url: 'https://api.jolpi.ca/ergast/f1/2023/2',
+          winnerDriverId: mockDriver.driverId,
+          winnerConstructorId: 'red_bull',
+          winnerTime: '1:33:56.736',
+          winnerLaps: 57,
+          winnerGrid: 1,
+          winnerPoints: 25,
+        },
+      ]);
+    });
+
+    it('should handle errors when fetching winner data', async () => {
+      const mockRacesResponse: ErgastResponse = {
+        MRData: {
+          xmlns: '',
+          series: '',
+          url: '',
+          limit: '',
+          offset: '',
+          total: '',
+          RaceTable: {
+            season: '2023',
+            Races: [
+              {
+                season: '2023',
+                round: '1',
+                raceName: 'Bahrain Grand Prix',
+                Circuit: {
+                  circuitId: 'bahrain',
+                  circuitName: 'Bahrain International Circuit',
+                  url: 'http://en.wikipedia.org/wiki/Bahrain_International_Circuit',
+                  Location: {
+                    lat: '26.0325',
+                    long: '50.5106',
+                    locality: 'Sakhir',
+                    country: 'Bahrain',
+                  },
+                },
+                date: '2023-03-05',
+                time: '15:00:00Z',
+                url: 'https://api.jolpi.ca/ergast/f1/2023/1',
+              },
+            ],
+          },
+        },
+      };
+
+      mockRepository.find.mockResolvedValue([]);
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: mockRacesResponse })
+        .mockRejectedValueOnce(new Error('API Error'));
+
+      await service['fetchAndStoreRacesBySeason'](2023);
+
+      // Verify that the race is still saved without winner data
+      expect(mockRepository.save).toHaveBeenCalledWith([
+        {
+          id: '2023-1',
+          season: 2023,
+          round: 1,
+          raceName: 'Bahrain Grand Prix',
+          circuitName: 'Bahrain International Circuit',
+          date: new Date('2023-03-05'),
+          time: '15:00:00Z',
+          url: 'https://api.jolpi.ca/ergast/f1/2023/1',
+        },
       ]);
     });
   });

--- a/src/seasons/seasons.module.ts
+++ b/src/seasons/seasons.module.ts
@@ -9,5 +9,6 @@ import { DriversModule } from '../drivers/drivers.module';
   imports: [TypeOrmModule.forFeature([Season]), DriversModule],
   controllers: [SeasonsController],
   providers: [SeasonsService],
+  exports: [SeasonsService],
 })
 export class SeasonsModule {}


### PR DESCRIPTION
- Added @nestjs/schedule package to manage scheduled tasks.
- Created JobsModule and JobsService to handle periodic synchronization of seasons and races.
- Implemented cron jobs to sync seasons and current season races every Sunday.
- Updated app.module.ts to include ScheduleModule and JobsModule.
- Enhanced RacesService to support fetching and storing races with winner data.
- Updated SeasonsService to fetch and store winners for seasons without winner data.